### PR TITLE
Fix typo of http.cors.allow-methods env var in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - discovery.type=single-node
       - "http.cors.enabled=true"
       - "http.cors.allow-origin=*"
-      - "http.cors.allow-methods: OPTIONS,HEAD,GET,POST,PUT,DELETE"
+      - "http.cors.allow-methods=OPTIONS,HEAD,GET,POST,PUT,DELETE"
       - "http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization"
       - "http.cors.allow-credentials=true"
       - bootstrap.memory_lock=true


### PR DESCRIPTION
Looks like there is a typo that improperly sets the `http.cors.allow-methods` environment variable.  Updated the docker-compose.yml to assign it properly.